### PR TITLE
minimal ide setup for c/c++

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,13 @@
-# starter.lvim
+# starter.lvim (C/C++ IDE)
 
 A great starting point for your LunarVim journey!
+
+## Requirements
+
+- [clangd](https://clangd.llvm.org)
+- [codelldb](https://github.com/vadimcn/vscode-lldb)
+
+install with mason `:MasonInstall clangd codelldb`
 
 ## Submission Guidelines
 

--- a/config.lua
+++ b/config.lua
@@ -1,0 +1,44 @@
+lvim.log.level = "warn"
+lvim.format_on_save = false
+lvim.leader = "space"
+lvim.lsp.diagnostics.virtual_text = true
+
+lvim.builtin.alpha.active = true
+lvim.builtin.alpha.mode = "dashboard"
+lvim.builtin.notify.active = true
+lvim.builtin.terminal.active = true
+lvim.builtin.nvimtree.setup.view.side = "left"
+lvim.builtin.nvimtree.setup.renderer.icons.show.git = false
+lvim.builtin.breadcrumbs.active = true
+lvim.builtin.treesitter.highlight.enable = true
+-- enable dap
+lvim.builtin.dap.active = true
+
+-- auto install treesitter parsers
+lvim.builtin.treesitter.ensure_installed = { "cpp", "c" }
+
+
+vim.list_extend(lvim.lsp.automatic_configuration.skipped_servers, { "clangd" })
+
+-- setup clangd
+
+-- customize clangd by changing the flags below
+local clangd_flags = {
+  "--background-index",
+  "--fallback-style=google",
+  "--all-scopes-completion",
+  "--clang-tidy",
+  "--log=error",
+  "--completion-style=detailed",
+  "--pch-storage=disk",
+  "--folding-ranges",
+  "--enable-config",
+}
+
+
+require("lvim.lsp.manager").setup("clangd", {
+  cmd = { "clangd", unpack(clangd_flags) },
+  on_attach = require("lvim.lsp").common_on_attach,
+  on_init = require("lvim.lsp").common_on_init,
+  capabilities = require("lvim.lsp").common_capabilities()
+})

--- a/config.lua
+++ b/config.lua
@@ -42,3 +42,36 @@ require("lvim.lsp.manager").setup("clangd", {
   on_init = require("lvim.lsp").common_on_init,
   capabilities = require("lvim.lsp").common_capabilities()
 })
+
+-- install codelldb with :MasonInstall codelldb
+-- configure nvim-dap (codelldb)
+lvim.builtin.dap.on_config_done = function(dap)
+  local codelldb_cmd = vim.fn.stdpath "data" .. "/mason/packages/codelldb/extension/adapter/codelldb"
+
+  dap.adapters.codelldb = {
+    type = 'server',
+    port = "${port}",
+    executable = {
+      command = codelldb_cmd,
+      args = { "--port", "${port}" },
+
+      -- On windows you may have to uncomment this:
+      -- detached = false,
+    }
+  }
+
+  dap.configurations.cpp = {
+    {
+      name = "Launch file",
+      type = "codelldb",
+      request = "launch",
+      program = function()
+        return vim.fn.input('Path to executable: ', vim.fn.getcwd() .. '/', 'file')
+      end,
+      cwd = '${workspaceFolder}',
+      stopOnEntry = true,
+    },
+  }
+
+  dap.configurations.c = dap.configurations.cpp
+end

--- a/config.lua
+++ b/config.lua
@@ -75,3 +75,14 @@ lvim.builtin.dap.on_config_done = function(dap)
 
   dap.configurations.c = dap.configurations.cpp
 end
+
+
+lvim.plugins = {
+  -- nvim-dap-virtual-text can be replaced with rcarriga/nvim-dap-ui
+  {
+    "theHamsta/nvim-dap-virtual-text",
+    config = function()
+      require("nvim-dap-virtual-text").setup()
+    end
+  }
+}

--- a/config.lua
+++ b/config.lua
@@ -46,13 +46,13 @@ require("lvim.lsp.manager").setup("clangd", {
 -- install codelldb with :MasonInstall codelldb
 -- configure nvim-dap (codelldb)
 lvim.builtin.dap.on_config_done = function(dap)
-  local codelldb_cmd = vim.fn.stdpath "data" .. "/mason/packages/codelldb/extension/adapter/codelldb"
 
   dap.adapters.codelldb = {
     type = 'server',
     port = "${port}",
     executable = {
-      command = codelldb_cmd,
+      -- provide the absolute path for `codelldb` command if not using the one installed using `mason.nvim`
+      command = "codelldb",
       args = { "--port", "${port}" },
 
       -- On windows you may have to uncomment this:


### PR DESCRIPTION
Tris to fix #5
- setup lsp(`clangd`) with some small manual configurations
- configure debugger adapter(`codelldb`)

There is no need to setup additional formatters and linters since `clangd` embeds `clang-tidy` and `clang-format`
