### PR TITLE
feat(c-ide): use `clangd_extensions.nvim`

### DIFF
--- a/config.lua
+++ b/config.lua
@@ -124,7 +124,8 @@ lvim.builtin.which_key.mappings["L"] = {
   a = { "<cmd>ClangdAST<CR>", "View AST" },
   s = { "<cmd>ClangdSymbolInfo<CR>", "View Symbol info" },
   t = { "<cmd>ClangdTypeHierarchy<CR>", "View Type hierarchy" },
-  h = { "<cmd>ClangdToggleInlayHints<CR>", "Toggle Inlay Hints" },
+  h = { "<cmd>ClangdSwitchSourceHeader<CR>", "Switch between source/header"},
+  H = { "<cmd>ClangdToggleInlayHints<CR>", "Toggle Inlay Hints" },
 }
 
 lvim.builtin.which_key.vmappings["L"] = {

--- a/config.lua
+++ b/config.lua
@@ -119,7 +119,7 @@ lvim.plugins = {
 -----------------------------------------------------------------------
 -- custom which-key mappings for commands provided by clangd_extensions
 -----------------------------------------------------------------------
-lvim.builtin.which_key.mappings["L"] = {
+lvim.builtin.which_key.mappings["C"] = {
   name = "Clangd",
   a = { "<cmd>ClangdAST<CR>", "View AST" },
   s = { "<cmd>ClangdSymbolInfo<CR>", "View Symbol info" },
@@ -128,7 +128,7 @@ lvim.builtin.which_key.mappings["L"] = {
   H = { "<cmd>ClangdToggleInlayHints<CR>", "Toggle Inlay Hints" },
 }
 
-lvim.builtin.which_key.vmappings["L"] = {
+lvim.builtin.which_key.vmappings["C"] = {
   name = "Clangd",
   a = { "<cmd>ClangdAST<CR>", "View AST" },
 }

--- a/config.lua
+++ b/config.lua
@@ -7,7 +7,10 @@ lvim.builtin.treesitter.highlight.enable = true
 lvim.builtin.treesitter.ensure_installed = { "cpp", "c" }
 
 vim.list_extend(lvim.lsp.automatic_configuration.skipped_servers, { "clangd" })
+
+----------------------------------------------------------------------
 -- setup clangd
+----------------------------------------------------------------------
 
 -- customize clangd by changing the flags below
 local clangd_flags = {
@@ -26,12 +29,56 @@ local clangd_flags = {
 local capabilities = require("lvim.lsp").common_capabilities()
 capabilities.offsetEncoding = { "utf-16" }
 
-require("lvim.lsp.manager").setup("clangd", {
-  cmd = { "clangd", unpack(clangd_flags) },
-  on_attach = require("lvim.lsp").common_on_attach,
-  on_init = require("lvim.lsp").common_on_init,
-  capabilities = capabilities,
-})
+pcall(function()
+  require("clangd_extensions").setup {
+    server = {
+      cmd = { "clangd", unpack(clangd_flags) },
+      on_attach = require("lvim.lsp").common_on_attach,
+      on_init = require("lvim.lsp").common_on_init,
+      capabilities = capabilities,
+    },
+    extensions = {
+      autoSetHints = true,
+      inlay_hints = {
+        only_current_line = false,
+        show_parameter_hints = false,
+        parameter_hints_prefix = "<- ",
+        other_hints_prefix = "=> ",
+        highlight = "Comment",
+        -- The highlight group priority for extmark
+        priority = 100,
+      },
+      ast = {
+        role_icons = {
+          type = "🄣",
+          declaration = "🄓",
+          expression = "🄔",
+          statement = ";",
+          specifier = "🄢",
+          ["template argument"] = "🆃",
+        },
+        kind_icons = {
+          Compound = "🄲",
+          Recovery = "🅁",
+          TranslationUnit = "🅄",
+          PackExpansion = "🄿",
+          TemplateTypeParm = "🅃",
+          TemplateTemplateParm = "🅃",
+          TemplateParamObject = "🅃",
+        },
+        highlights = {
+          detail = "Comment",
+        },
+      },
+      memory_usage = {
+        border = "rounded",
+      },
+      symbol_info = {
+        border = "rounded",
+      },
+    },
+  }
+end)
 
 -- install codelldb with :MasonInstall codelldb
 -- configure nvim-dap (codelldb)
@@ -64,3 +111,23 @@ lvim.builtin.dap.on_config_done = function(dap)
 
   dap.configurations.c = dap.configurations.cpp
 end
+
+lvim.plugins = {
+  "p00f/clangd_extensions.nvim",
+}
+
+-----------------------------------------------------------------------
+-- custom which-key mappings for commands provided by clangd_extensions
+-----------------------------------------------------------------------
+lvim.builtin.which_key.mappings["L"] = {
+  name = "Clangd",
+  a = { "<cmd>ClangdAST<CR>", "View AST" },
+  s = { "<cmd>ClangdSymbolInfo<CR>", "View Symbol info" },
+  t = { "<cmd>ClangdTypeHierarchy<CR>", "View Type hierarchy" },
+  h = { "<cmd>ClangdToggleInlayHints<CR>", "Toggle Inlay Hints" },
+}
+
+lvim.builtin.which_key.vmappings["L"] = {
+  name = "Clangd",
+  a = { "<cmd>ClangdAST<CR>", "View AST" },
+}


### PR DESCRIPTION
adds features like `inlay hints`(can be toggled), view [Type hierarchy](https://clangd.llvm.org/extensions#type-hierarchy), view [AST](https://clangd.llvm.org/extensions#ast), view [symbol info](https://clangd.llvm.org/extensions#symbol-info-request) and sets up which key mappings for cmds provided by `clangd_extensions`