### PR TITLE
feat(rust-ide): add which-key mappings for `crates.nvim` functions

### DIFF
--- a/.stylua.toml
+++ b/.stylua.toml
@@ -1,0 +1,6 @@
+column_width = 120
+line_endings = "Unix"
+indent_type = "Spaces"
+indent_width = 2
+quote_style = "AutoPreferDouble"
+no_call_parentheses = true

--- a/config.lua
+++ b/config.lua
@@ -118,15 +118,11 @@ lvim.builtin.which_key.mappings["L"] = {
 		"Reload Workspace",
 	},
 	o = { "<cmd>RustOpenExternalDocs<Cr>", "Open External Docs" },
-}
-
-lvim.builtin.which_key.mappings["C"] = {
-  name = "Crates",
-  r = { "<cmd>lua require'crates'.open_repository()<cr>", "visit crate's repository" },
-  p = { "<cmd>lua require'crates'.show_popup()<cr>", "show popup" },
-  c = { "<cmd>lua require'crates'.show_crate_popup()<cr>", "crates info" },
-  f = { "<cmd>lua require'crates'.show_features_popup()<cr>", "features info" },
-  d = { "<cmd>lua require'crates'.show_dependencies_popup()<cr>", "dependencies info" },
+  y = { "<cmd>lua require'crates'.open_repository()<cr>", "[crates] open repository" },
+  P = { "<cmd>lua require'crates'.show_popup()<cr>", "[crates] show popup" },
+  i = { "<cmd>lua require'crates'.show_crate_popup()<cr>", "[crates] show info" },
+  f = { "<cmd>lua require'crates'.show_features_popup()<cr>", "[crates] show features" },
+  D = { "<cmd>lua require'crates'.show_dependencies_popup()<cr>", "[crates] show dependencies" },
 }
 
 lvim.plugins = {

--- a/config.lua
+++ b/config.lua
@@ -132,6 +132,9 @@ lvim.plugins = {
 					enabled = true,
 					name = "crates.nvim",
 				},
+        popup = {
+          border = "rounded"
+        }
 			}
 		end,
 	},

--- a/config.lua
+++ b/config.lua
@@ -5,9 +5,6 @@ lvim.builtin.treesitter.ensure_installed = {
   "toml",
 }
 
-lvim.builtin.dap.active = true
-lvim.builtin.treesitter.highlight.enable = true
-
 vim.list_extend(lvim.lsp.automatic_configuration.skipped_servers, { "rust_analyzer" })
 
 local formatters = require "lvim.lsp.null-ls.formatters"

--- a/config.lua
+++ b/config.lua
@@ -120,6 +120,15 @@ lvim.builtin.which_key.mappings["L"] = {
 	o = { "<cmd>RustOpenExternalDocs<Cr>", "Open External Docs" },
 }
 
+lvim.builtin.which_key.mappings["C"] = {
+  name = "Crates",
+  r = { "<cmd>lua require'crates'.open_repository()<cr>", "visit crate's repository" },
+  p = { "<cmd>lua require'crates'.show_popup()<cr>", "show popup" },
+  c = { "<cmd>lua require'crates'.show_crate_popup()<cr>", "crates info" },
+  f = { "<cmd>lua require'crates'.show_features_popup()<cr>", "features info" },
+  d = { "<cmd>lua require'crates'.show_dependencies_popup()<cr>", "dependencies info" },
+}
+
 lvim.plugins = {
 	"simrat39/rust-tools.nvim",
 	{

--- a/config.lua
+++ b/config.lua
@@ -1,8 +1,8 @@
 -- if you don't want all the parsers change this to a table of the ones you want
 lvim.builtin.treesitter.ensure_installed = {
-	"lua",
-	"rust",
-	"toml",
+  "lua",
+  "rust",
+  "toml",
 }
 
 lvim.builtin.dap.active = true
@@ -12,112 +12,111 @@ vim.list_extend(lvim.lsp.automatic_configuration.skipped_servers, { "rust_analyz
 
 local formatters = require "lvim.lsp.null-ls.formatters"
 formatters.setup {
-	{ command = "stylua", filetypes = { "lua" } },
+  { command = "stylua", filetypes = { "lua" } },
 }
 
 local mason_path = vim.fn.glob(vim.fn.stdpath "data" .. "/mason/")
 local codelldb_adapter = {
-	type = "server",
-	port = "${port}",
-	executable = {
-		command = mason_path .. "bin/codelldb",
-		args = { "--port", "${port}" },
-		-- On windows you may have to uncomment this:
-		-- detached = false,
-	},
+  type = "server",
+  port = "${port}",
+  executable = {
+    command = mason_path .. "bin/codelldb",
+    args = { "--port", "${port}" },
+    -- On windows you may have to uncomment this:
+    -- detached = false,
+  },
 }
 
 pcall(function()
-	require("rust-tools").setup {
-		tools = {
-			executor = require("rust-tools/executors").termopen, -- can be quickfix or termopen
-			reload_workspace_from_cargo_toml = true,
-			runnables = {
-				use_telescope = true,
-			},
-			inlay_hints = {
-				auto = true,
-				only_current_line = false,
-				show_parameter_hints = false,
-				parameter_hints_prefix = "<-",
-				other_hints_prefix = "=>",
-				max_len_align = false,
-				max_len_align_padding = 1,
-				right_align = false,
-				right_align_padding = 7,
-				highlight = "Comment",
-			},
-			hover_actions = {
-				border = "rounded",
-			},
-			on_initialized = function()
-				vim.api.nvim_create_autocmd({ "BufWritePost", "BufEnter", "CursorHold", "InsertLeave" }, {
-					pattern = { "*.rs" },
-					callback = function()
-						local _, _ = pcall(vim.lsp.codelens.refresh)
-					end,
-				})
-			end,
-		},
-		dap = {
-			adapter = codelldb_adapter,
-		},
-		server = {
-			on_attach = function(client, bufnr)
-				require("lvim.lsp").common_on_attach(client, bufnr)
-				local rt = require "rust-tools"
-				vim.keymap.set("n", "K", rt.hover_actions.hover_actions, { buffer = bufnr })
-			end,
+  require("rust-tools").setup {
+    tools = {
+      executor = require("rust-tools/executors").termopen, -- can be quickfix or termopen
+      reload_workspace_from_cargo_toml = true,
+      runnables = {
+        use_telescope = true,
+      },
+      inlay_hints = {
+        auto = true,
+        only_current_line = false,
+        show_parameter_hints = false,
+        parameter_hints_prefix = "<-",
+        other_hints_prefix = "=>",
+        max_len_align = false,
+        max_len_align_padding = 1,
+        right_align = false,
+        right_align_padding = 7,
+        highlight = "Comment",
+      },
+      hover_actions = {
+        border = "rounded",
+      },
+      on_initialized = function()
+        vim.api.nvim_create_autocmd({ "BufWritePost", "BufEnter", "CursorHold", "InsertLeave" }, {
+          pattern = { "*.rs" },
+          callback = function()
+            local _, _ = pcall(vim.lsp.codelens.refresh)
+          end,
+        })
+      end,
+    },
+    dap = {
+      adapter = codelldb_adapter,
+    },
+    server = {
+      on_attach = function(client, bufnr)
+        require("lvim.lsp").common_on_attach(client, bufnr)
+        local rt = require "rust-tools"
+        vim.keymap.set("n", "K", rt.hover_actions.hover_actions, { buffer = bufnr })
+      end,
 
-			capabilities = require("lvim.lsp").common_capabilities(),
-			settings = {
-				["rust-analyzer"] = {
-					lens = {
-						enable = true,
-					},
-					checkOnSave = {
-						enable = true,
-						command = "clippy",
-					},
-				},
-			},
-		},
-	}
+      capabilities = require("lvim.lsp").common_capabilities(),
+      settings = {
+        ["rust-analyzer"] = {
+          lens = {
+            enable = true,
+          },
+          checkOnSave = {
+            enable = true,
+            command = "clippy",
+          },
+        },
+      },
+    },
+  }
 end)
 
--- CHANGED --
 lvim.builtin.dap.on_config_done = function(dap)
-	dap.adapters.codelldb = codelldb_adapter
-	dap.configurations.rust = {
-		{
-			name = "Launch file",
-			type = "codelldb",
-			request = "launch",
-			program = function()
-				return vim.fn.input("Path to executable: ", vim.fn.getcwd() .. "/", "file")
-			end,
-			cwd = "${workspaceFolder}",
-			stopOnEntry = false,
-		},
-	}
+  dap.adapters.codelldb = codelldb_adapter
+  dap.configurations.rust = {
+    {
+      name = "Launch file",
+      type = "codelldb",
+      request = "launch",
+      program = function()
+        return vim.fn.input("Path to executable: ", vim.fn.getcwd() .. "/", "file")
+      end,
+      cwd = "${workspaceFolder}",
+      stopOnEntry = false,
+    },
+  }
 end
 
 vim.api.nvim_set_keymap("n", "<m-d>", "<cmd>RustOpenExternalDocs<Cr>", { noremap = true, silent = true })
 
 lvim.builtin.which_key.mappings["C"] = {
-	name = "Rust",
-	r = { "<cmd>RustRunnables<Cr>", "Runnables" },
-	t = { "<cmd>lua _CARGO_TEST()<cr>", "Cargo Test" },
-	m = { "<cmd>RustExpandMacro<Cr>", "Expand Macro" },
-	c = { "<cmd>RustOpenCargo<Cr>", "Open Cargo" },
-	p = { "<cmd>RustParentModule<Cr>", "Parent Module" },
-	d = { "<cmd>RustDebuggables<Cr>", "Debuggables" },
-	v = { "<cmd>RustViewCrateGraph<Cr>", "View Crate Graph" },
-	R = {
-		"<cmd>lua require('rust-tools/workspace_refresh')._reload_workspace_from_cargo_toml()<Cr>",
-		"Reload Workspace",
-	},
-	o = { "<cmd>RustOpenExternalDocs<Cr>", "Open External Docs" },
+  name = "Rust",
+  r = { "<cmd>RustRunnables<Cr>", "Runnables" },
+  t = { "<cmd>lua _CARGO_TEST()<cr>", "Cargo Test" },
+  m = { "<cmd>RustExpandMacro<Cr>", "Expand Macro" },
+  c = { "<cmd>RustOpenCargo<Cr>", "Open Cargo" },
+  p = { "<cmd>RustParentModule<Cr>", "Parent Module" },
+  d = { "<cmd>RustDebuggables<Cr>", "Debuggables" },
+  v = { "<cmd>RustViewCrateGraph<Cr>", "View Crate Graph" },
+  R = {
+    "<cmd>lua require('rust-tools/workspace_refresh')._reload_workspace_from_cargo_toml()<Cr>",
+    "Reload Workspace",
+  },
+  o = { "<cmd>RustOpenExternalDocs<Cr>", "Open External Docs" },
   y = { "<cmd>lua require'crates'.open_repository()<cr>", "[crates] open repository" },
   P = { "<cmd>lua require'crates'.show_popup()<cr>", "[crates] show popup" },
   i = { "<cmd>lua require'crates'.show_crate_popup()<cr>", "[crates] show info" },
@@ -126,27 +125,27 @@ lvim.builtin.which_key.mappings["C"] = {
 }
 
 lvim.plugins = {
-	"simrat39/rust-tools.nvim",
-	{
-		"saecki/crates.nvim",
-		tag = "v0.3.0",
-		requires = { "nvim-lua/plenary.nvim" },
-		config = function()
-			require("crates").setup {
-				null_ls = {
-					enabled = true,
-					name = "crates.nvim",
-				},
+  "simrat39/rust-tools.nvim",
+  {
+    "saecki/crates.nvim",
+    tag = "v0.3.0",
+    requires = { "nvim-lua/plenary.nvim" },
+    config = function()
+      require("crates").setup {
+        null_ls = {
+          enabled = true,
+          name = "crates.nvim",
+        },
         popup = {
-          border = "rounded"
-        }
-			}
-		end,
-	},
-	{
-		"j-hui/fidget.nvim",
-		config = function()
-			require("fidget").setup()
-		end,
-	},
+          border = "rounded",
+        },
+      }
+    end,
+  },
+  {
+    "j-hui/fidget.nvim",
+    config = function()
+      require("fidget").setup()
+    end,
+  },
 }

--- a/config.lua
+++ b/config.lua
@@ -104,7 +104,7 @@ end
 
 vim.api.nvim_set_keymap("n", "<m-d>", "<cmd>RustOpenExternalDocs<Cr>", { noremap = true, silent = true })
 
-lvim.builtin.which_key.mappings["L"] = {
+lvim.builtin.which_key.mappings["C"] = {
 	name = "Rust",
 	r = { "<cmd>RustRunnables<Cr>", "Runnables" },
 	t = { "<cmd>lua _CARGO_TEST()<cr>", "Cargo Test" },


### PR DESCRIPTION
- change which-key prefix from `L` to `C` 
- Add keybinds for functions provided by `crates.nvim` that don't appear as code action 
- Have rounded borders for popups of `crates.nvim` so they look consistent with LunarVim's UI