### PR TITLE
Fix(java-ide): Add missing on_attach functionality

### DIFF
--- a/ftplugin/java.lua
+++ b/ftplugin/java.lua
@@ -197,7 +197,7 @@ config["on_attach"] = function(client, bufnr)
 	local _, _ = pcall(vim.lsp.codelens.refresh)
 	require("jdtls.dap").setup_dap_main_class_configs()
 	require("jdtls").setup_dap({ hotcodereplace = "auto" })
-	require("lvim.lsp").on_attach(client, bufnr)
+	require("lvim.lsp").common_on_attach(client, bufnr)
 end
 
 vim.api.nvim_create_autocmd({ "BufWritePost" }, {


### PR DESCRIPTION
By calling on_attach instead of common_on_attach, the LSP buffer keymaps were never attached to the Java LSP instance.