### PR TITLE
fix(go-ide): Maintain consistency between language which-key mappings + add GoIfErr mapping

### DIFF
--- a/config.lua
+++ b/config.lua
@@ -78,7 +78,7 @@ gopher.setup {
 ------------------------
 -- Language Key Mappings
 ------------------------
-lvim.builtin.which_key.mappings["L"] = {
+lvim.builtin.which_key.mappings["C"] = {
   name = "Go",
   i = { "<cmd>GoInstallDeps<Cr>", "Install Go Dependencies" },
   t = { "<cmd>GoMod tidy<cr>", "Tidy" },
@@ -88,6 +88,7 @@ lvim.builtin.which_key.mappings["L"] = {
   g = { "<cmd>GoGenerate<Cr>", "Go Generate" },
   f = { "<cmd>GoGenerate %<Cr>", "Go Generate File" },
   c = { "<cmd>GoCmt<Cr>", "Generate Comment" },
+  r = { "<cmd>GoIfErr<Cr>", "Add if err" },
 }
 
 ------------------------

--- a/ftplugin/go.lua
+++ b/ftplugin/go.lua
@@ -1,0 +1,16 @@
+------------------------
+-- Language Key Mappings
+------------------------
+lvim.builtin.which_key.mappings["C"] = {
+  name = "Go",
+  i = { "<cmd>GoInstallDeps<Cr>", "Install Go Dependencies" },
+  t = { "<cmd>GoMod tidy<cr>", "Tidy" },
+  a = { "<cmd>GoTestAdd<Cr>", "Add Test" },
+  A = { "<cmd>GoTestsAll<Cr>", "Add All Tests" },
+  e = { "<cmd>GoTestsExp<Cr>", "Add Exported Tests" },
+  g = { "<cmd>GoGenerate<Cr>", "Go Generate" },
+  f = { "<cmd>GoGenerate %<Cr>", "Go Generate File" },
+  c = { "<cmd>GoCmt<Cr>", "Generate Comment" },
+  r = { "<cmd>GoIfErr<Cr>", "Add if err" },
+}
+lvim.builtin.which_key.mappings["dT"] = { "<cmd>lua require('dap-go').debug_test()<cr>", "Debug Test" }


### PR DESCRIPTION
- ~~Changed the prefix for the language to `C` according to the latest stream suggestions.~~
- Added `GoIfErr` as another which key mapping for `Go`
- Move `which-key` mappings to `ftplugin/go.lua` so as to keep consistency (across all IDEs) of setting `which-key` mappings but also only affect when it is a `go` filetype.