### PR TITLE
fix(java-ide): Make keymaps buffer specific

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,9 @@
 # starter.lvim
+
 A great starting point for your LunarVim journey!
+
+## Submission Guidelines
+
+- Ideally one file!
+- IDE config must be added to its own branch named `lang-ide`
+- try to keep it focused on the language and not your biased keybindings/options

--- a/ftplugin/java.lua
+++ b/ftplugin/java.lua
@@ -20,6 +20,54 @@ elseif vim.fn.has("unix") == 1 then
 else
 	print("Unsupported system")
 end
+local function set_keymaps(buffer)
+	local status_ok, which_key = pcall(require, "which-key")
+	if not status_ok then
+		return
+	end
+
+	local opts = {
+		mode = "n", -- NORMAL mode
+		prefix = "<leader>",
+		buffer = buffer, -- Global mappings. Specify a buffer number for buffer local mappings
+		silent = true, -- use `silent` when creating keymaps
+		noremap = true, -- use `noremap` when creating keymaps
+		nowait = true, -- use `nowait` when creating keymaps
+	}
+
+	local vopts = {
+		mode = "v", -- VISUAL mode
+		prefix = "<leader>",
+		buffer = buffer, -- Global mappings. Specify a buffer number for buffer local mappings
+		silent = true, -- use `silent` when creating keymaps
+		noremap = true, -- use `noremap` when creating keymaps
+		nowait = true, -- use `nowait` when creating keymaps
+	}
+
+	local mappings = {
+		L = {
+			name = "Java",
+			o = { "<Cmd>lua require'jdtls'.organize_imports()<CR>", "Organize Imports" },
+			v = { "<Cmd>lua require('jdtls').extract_variable()<CR>", "Extract Variable" },
+			c = { "<Cmd>lua require('jdtls').extract_constant()<CR>", "Extract Constant" },
+			t = { "<Cmd>lua require'jdtls'.test_nearest_method()<CR>", "Test Method" },
+			T = { "<Cmd>lua require'jdtls'.test_class()<CR>", "Test Class" },
+			u = { "<Cmd>JdtUpdateConfig<CR>", "Update Config" },
+		},
+	}
+
+	local vmappings = {
+		L = {
+			name = "Java",
+			v = { "<Esc><Cmd>lua require('jdtls').extract_variable(true)<CR>", "Extract Variable" },
+			c = { "<Esc><Cmd>lua require('jdtls').extract_constant(true)<CR>", "Extract Constant" },
+			m = { "<Esc><Cmd>lua require('jdtls').extract_method(true)<CR>", "Extract Method" },
+		},
+	}
+
+	which_key.register(mappings, opts)
+	which_key.register(vmappings, vopts)
+end
 
 -- Find root of project
 local root_markers = { ".git", "mvnw", "gradlew", "pom.xml", "build.gradle" }
@@ -198,6 +246,7 @@ config["on_attach"] = function(client, bufnr)
 	require("jdtls.dap").setup_dap_main_class_configs()
 	require("jdtls").setup_dap({ hotcodereplace = "auto" })
 	require("lvim.lsp").on_attach(client, bufnr)
+	set_keymaps(bufnr)
 end
 
 vim.api.nvim_create_autocmd({ "BufWritePost" }, {
@@ -219,51 +268,3 @@ vim.cmd(
 -- -- vim.cmd "command! -buffer JdtJol lua require('jdtls').jol()"
 -- vim.cmd "command! -buffer JdtBytecode lua require('jdtls').javap()"
 -- -- vim.cmd "command! -buffer JdtJshell lua require('jdtls').jshell()"
-
-local status_ok, which_key = pcall(require, "which-key")
-if not status_ok then
-	return
-end
-
-local opts = {
-	mode = "n", -- NORMAL mode
-	prefix = "<leader>",
-	buffer = nil, -- Global mappings. Specify a buffer number for buffer local mappings
-	silent = true, -- use `silent` when creating keymaps
-	noremap = true, -- use `noremap` when creating keymaps
-	nowait = true, -- use `nowait` when creating keymaps
-}
-
-local vopts = {
-	mode = "v", -- VISUAL mode
-	prefix = "<leader>",
-	buffer = nil, -- Global mappings. Specify a buffer number for buffer local mappings
-	silent = true, -- use `silent` when creating keymaps
-	noremap = true, -- use `noremap` when creating keymaps
-	nowait = true, -- use `nowait` when creating keymaps
-}
-
-local mappings = {
-	L = {
-		name = "Java",
-		o = { "<Cmd>lua require'jdtls'.organize_imports()<CR>", "Organize Imports" },
-		v = { "<Cmd>lua require('jdtls').extract_variable()<CR>", "Extract Variable" },
-		c = { "<Cmd>lua require('jdtls').extract_constant()<CR>", "Extract Constant" },
-		t = { "<Cmd>lua require'jdtls'.test_nearest_method()<CR>", "Test Method" },
-		T = { "<Cmd>lua require'jdtls'.test_class()<CR>", "Test Class" },
-		u = { "<Cmd>JdtUpdateConfig<CR>", "Update Config" },
-	},
-}
-
-local vmappings = {
-	L = {
-		name = "Java",
-		v = { "<Esc><Cmd>lua require('jdtls').extract_variable(true)<CR>", "Extract Variable" },
-		c = { "<Esc><Cmd>lua require('jdtls').extract_constant(true)<CR>", "Extract Constant" },
-		m = { "<Esc><Cmd>lua require('jdtls').extract_method(true)<CR>", "Extract Method" },
-	},
-}
-
-which_key.register(mappings, opts)
-which_key.register(vmappings, vopts)
-which_key.register(vmappings, vopts)


### PR DESCRIPTION
This is desired in the scenario when you are working on multiple projects of different languages. With the old implementation you'll end up with dangling keymaps for language X when doing work for language Y.