### PR TITLE
fix(go-ide): Make keymaps buffer specific

### DIFF
--- a/config.lua
+++ b/config.lua
@@ -58,7 +58,7 @@ local function set_keymaps(buffer)
   }
 
   local mappings = {
-    L = {
+    C = {
       name = "Go",
       i = { "<cmd>GoInstallDeps<Cr>", "Install Go Dependencies" },
       t = { "<cmd>GoMod tidy<cr>", "Tidy" },

--- a/config.lua
+++ b/config.lua
@@ -42,41 +42,6 @@ dapgo.setup()
 ------------------------
 vim.list_extend(lvim.lsp.automatic_configuration.skipped_servers, { "gopls" })
 
-local function set_keymaps(buffer)
-  local status_ok, which_key = pcall(require, "which-key")
-  if not status_ok then
-    return
-  end
-
-  local opts = {
-    mode = "n", -- NORMAL mode
-    prefix = "<leader>",
-    buffer = buffer, -- Global mappings. Specify a buffer number for buffer local mappings
-    silent = true, -- use `silent` when creating keymaps
-    noremap = true, -- use `noremap` when creating keymaps
-    nowait = true, -- use `nowait` when creating keymaps
-  }
-
-  local mappings = {
-    C = {
-      name = "Go",
-      i = { "<cmd>GoInstallDeps<Cr>", "Install Go Dependencies" },
-      t = { "<cmd>GoMod tidy<cr>", "Tidy" },
-      a = { "<cmd>GoTestAdd<Cr>", "Add Test" },
-      A = { "<cmd>GoTestsAll<Cr>", "Add All Tests" },
-      e = { "<cmd>GoTestsExp<Cr>", "Add Exported Tests" },
-      g = { "<cmd>GoGenerate<Cr>", "Go Generate" },
-      f = { "<cmd>GoGenerate %<Cr>", "Go Generate File" },
-      c = { "<cmd>GoCmt<Cr>", "Generate Comment" },
-    },
-    D = {
-      name = "Debug",
-      T = { "<cmd>lua require('dap-go').debug_test()<cr>", "Debug Test" }
-    }
-  }
-  which_key.register(mappings, opts)
-end
-
 local lsp_manager = require "lvim.lsp.manager"
 lsp_manager.setup("golangci_lint_ls", {
   on_init = require("lvim.lsp").common_on_init,
@@ -87,7 +52,22 @@ lsp_manager.setup("gopls", {
   on_attach = function(client, bufnr)
     require("lvim.lsp").common_on_attach(client, bufnr)
     local _, _ = pcall(vim.lsp.codelens.refresh)
-    set_keymaps(bufnr)
+    local map = function(mode, lhs, rhs, desc)
+      if desc then
+        desc = desc
+      end
+
+      vim.keymap.set(mode, lhs, rhs, { silent = true, desc = desc, buffer = bufnr, noremap = true })
+    end
+    map("<leader>Ci", "<cmd>GoInstallDeps<Cr>", "Install Go Dependencies")
+    map("<leader>Ct", "<cmd>GoMod tidy<cr>", "Tidy")
+    map("<leader>Ca", "<cmd>GoTestAdd<Cr>", "Add Test")
+    map("<leader>CA", "<cmd>GoTestsAll<Cr>", "Add All Tests")
+    map("<leader>Ce", "<cmd>GoTestsExp<Cr>", "Add Exported Tests")
+    map("<leader>Cg", "<cmd>GoGenerate<Cr>", "Go Generate")
+    map("<leader>Cf", "<cmd>GoGenerate %<Cr>", "Go Generate File")
+    map("<leader>Cc", "<cmd>GoCmt<Cr>", "Generate Comment")
+    map("<leader>DT", "<cmd>lua require('dap-go').debug_test()<cr>", "Debug Test")
   end,
   on_init = require("lvim.lsp").common_on_init,
   capabilities = require("lvim.lsp").common_capabilities(),

--- a/config.lua
+++ b/config.lua
@@ -27,11 +27,55 @@ lvim.format_on_save = {
   pattern = { "*.go" },
 }
 
+------------------------
+-- Dap
+------------------------
+local dap_ok, dapgo = pcall(require, "dap-go")
+if not dap_ok then
+  return
+end
+
+dapgo.setup()
 
 ------------------------
 -- LSP
 ------------------------
 vim.list_extend(lvim.lsp.automatic_configuration.skipped_servers, { "gopls" })
+
+local function set_keymaps(buffer)
+  local status_ok, which_key = pcall(require, "which-key")
+  if not status_ok then
+    return
+  end
+
+  local opts = {
+    mode = "n", -- NORMAL mode
+    prefix = "<leader>",
+    buffer = buffer, -- Global mappings. Specify a buffer number for buffer local mappings
+    silent = true, -- use `silent` when creating keymaps
+    noremap = true, -- use `noremap` when creating keymaps
+    nowait = true, -- use `nowait` when creating keymaps
+  }
+
+  local mappings = {
+    L = {
+      name = "Go",
+      i = { "<cmd>GoInstallDeps<Cr>", "Install Go Dependencies" },
+      t = { "<cmd>GoMod tidy<cr>", "Tidy" },
+      a = { "<cmd>GoTestAdd<Cr>", "Add Test" },
+      A = { "<cmd>GoTestsAll<Cr>", "Add All Tests" },
+      e = { "<cmd>GoTestsExp<Cr>", "Add Exported Tests" },
+      g = { "<cmd>GoGenerate<Cr>", "Go Generate" },
+      f = { "<cmd>GoGenerate %<Cr>", "Go Generate File" },
+      c = { "<cmd>GoCmt<Cr>", "Generate Comment" },
+    },
+    D = {
+      name = "Debug",
+      T = { "<cmd>lua require('dap-go').debug_test()<cr>", "Debug Test" }
+    }
+  }
+  which_key.register(mappings, opts)
+end
 
 local lsp_manager = require "lvim.lsp.manager"
 lsp_manager.setup("golangci_lint_ls", {
@@ -43,6 +87,7 @@ lsp_manager.setup("gopls", {
   on_attach = function(client, bufnr)
     require("lvim.lsp").common_on_attach(client, bufnr)
     local _, _ = pcall(vim.lsp.codelens.refresh)
+    set_keymaps(bufnr)
   end,
   on_init = require("lvim.lsp").common_on_init,
   capabilities = require("lvim.lsp").common_capabilities(),
@@ -74,30 +119,3 @@ gopher.setup {
     iferr = "iferr",
   },
 }
-
-------------------------
--- Language Key Mappings
-------------------------
-lvim.builtin.which_key.mappings["L"] = {
-  name = "Go",
-  i = { "<cmd>GoInstallDeps<Cr>", "Install Go Dependencies" },
-  t = { "<cmd>GoMod tidy<cr>", "Tidy" },
-  a = { "<cmd>GoTestAdd<Cr>", "Add Test" },
-  A = { "<cmd>GoTestsAll<Cr>", "Add All Tests" },
-  e = { "<cmd>GoTestsExp<Cr>", "Add Exported Tests" },
-  g = { "<cmd>GoGenerate<Cr>", "Go Generate" },
-  f = { "<cmd>GoGenerate %<Cr>", "Go Generate File" },
-  c = { "<cmd>GoCmt<Cr>", "Generate Comment" },
-}
-
-------------------------
--- Dap
-------------------------
-local dap_ok, dapgo = pcall(require, "dap-go")
-if not dap_ok then
-  return
-end
-
-dapgo.setup()
-
-lvim.builtin.which_key.mappings["dT"] = { "<cmd>lua require('dap-go').debug_test()<cr>", "Debug Test" }


### PR DESCRIPTION
This is desired in the scenario when you are working on multiple projects of different languages. With the old implementation you'll end up with dangling keymaps for language X when doing work for language Y.

Solves #42 for go-ide