### PR TITLE
Remove deprecated lvim.builtin.notify.active

### DIFF
--- a/config.lua
+++ b/config.lua
@@ -6,7 +6,6 @@ lvim.leader = "space"
 -- After changing plugin config exit and reopen LunarVim, Run :PackerInstall :PackerCompile
 lvim.builtin.alpha.active = true
 lvim.builtin.alpha.mode = "dashboard"
-lvim.builtin.notify.active = true
 lvim.builtin.terminal.active = true
 lvim.builtin.nvimtree.setup.view.side = "left"
 lvim.builtin.nvimtree.setup.renderer.icons.show.git = false


### PR DESCRIPTION
The starter config in the java-ide branch is toggling the lvim.builtin.notify.active setting which was deprecated as part of LunarVim#3294