### PR TITLE
revised debugging for rust-tools due to changes in nvim 0.9

### DIFF
--- a/config.lua
+++ b/config.lua
@@ -13,16 +13,19 @@ formatters.setup {
 }
 
 local mason_path = vim.fn.glob(vim.fn.stdpath "data" .. "/mason/")
-local codelldb_adapter = {
-  type = "server",
-  port = "${port}",
-  executable = {
-    command = mason_path .. "bin/codelldb",
-    args = { "--port", "${port}" },
-    -- On windows you may have to uncomment this:
-    -- detached = false,
-  },
-}
+
+local codelldb_path = mason_path .. "bin/codelldb"
+local liblldb_path = mason_path .. "packages/codelldb/extension/lldb/lib/liblldb"
+local this_os = vim.loop.os_uname().sysname
+
+-- The path in windows is different
+if this_os:find "Windows" then
+  codelldb_path = mason_path .. "packages\\codelldb\\extension\\adapter\\codelldb.exe"
+  liblldb_path = mason_path .. "packages\\codelldb\\extension\\lldb\\bin\\liblldb.dll"
+else
+  -- The liblldb extension is .so for linux and .dylib for macOS
+  liblldb_path = liblldb_path .. (this_os == "Linux" and ".so" or ".dylib")
+end
 
 pcall(function()
   require("rust-tools").setup {
@@ -57,7 +60,8 @@ pcall(function()
       end,
     },
     dap = {
-      adapter = codelldb_adapter,
+      -- adapter= codelldb_adapter,
+      adapter = require("rust-tools.dap").get_codelldb_adapter(codelldb_path, liblldb_path),
     },
     server = {
       on_attach = function(client, bufnr)
@@ -83,7 +87,7 @@ pcall(function()
 end)
 
 lvim.builtin.dap.on_config_done = function(dap)
-  dap.adapters.codelldb = codelldb_adapter
+  dap.adapters.codelldb = require("rust-tools.dap").get_codelldb_adapter(codelldb_path, liblldb_path)
   dap.configurations.rust = {
     {
       name = "Launch file",


### PR DESCRIPTION
the rust-ide is using rust-tools which was working with lvim 1.2 / nvim 0.8 but it is broken in lvim 1.3 /nvim 0.9. 
After openning an issue at rust-tool repo, 
https://github.com/simrat39/rust-tools.nvim/issues/378
I learned the revised way to make it work with codelldb as it was explained at
https://github.com/simrat39/rust-tools.nvim/wiki/Debugging
I made changes for lvim runtime since we are using Mason and now it works using rust-tool debuggables mapped key.
![image](https://user-images.githubusercontent.com/46407603/236643843-1528673e-89e9-45c3-9660-d87c4bc4e5b0.png)
![image](https://user-images.githubusercontent.com/46407603/236643876-8cf6d74e-f981-4b0e-afdd-38c1f637eb74.png)

I only changed the debugging section ; here are the added / changed code ;
```
local codelldb_path = mason_path .. "bin/codelldb"
local liblldb_path = mason_path .. "packages/codelldb/extension/lldb/lib/liblldb"
local this_os = vim.loop.os_uname().sysname

-- The path in windows is different
if this_os:find "Windows" then
  codelldb_path = mason_path .. "packages\\codelldb\\extension\\adapter\\codelldb.exe"
  liblldb_path = mason_path .. "packages\\codelldb\\extension\\lldb\\bin\\liblldb.dll"
else
  -- The liblldb extension is .so for linux and .dylib for macOS
  liblldb_path = liblldb_path .. (this_os == "Linux" and ".so" or ".dylib")
end
```
also the dap in rust-tool setup 
```
    dap = {
      -- adapter= codelldb_adapter,
      adapter = require("rust-tools.dap").get_codelldb_adapter(codelldb_path, liblldb_path),
    },
```
and config_on_done part ;
```
lvim.builtin.dap.on_config_done = function(dap)
  dap.adapters.codelldb = require("rust-tools.dap").get_codelldb_adapter(codelldb_path, liblldb_path)
  dap.configurations.rust = {
    {
      name = "Launch file",
      type = "codelldb",
      request = "launch",
      program = function()
        return vim.fn.input("Path to executable: ", vim.fn.getcwd() .. "/", "file")
      end,
      cwd = "${workspaceFolder}",
      stopOnEntry = false,
    },
  }
end

```
The windows path might need to be checked since I only tested on linux
Also note dap-ui does not automatically popup in lvim 1.3 , which I believe due to lazy loading. 
Hope this  helps.
Salim


