### PR TITLE
fix(rust-ide): rename tag->version & requires->dependencies in lvim.plugins

### DIFF
--- a/config.lua
+++ b/config.lua
@@ -129,8 +129,8 @@ lvim.plugins = {
   "simrat39/rust-tools.nvim",
   {
     "saecki/crates.nvim",
-    tag = "v0.3.0",
-    requires = { "nvim-lua/plenary.nvim" },
+    version = "v0.3.0",
+    dependencies = { "nvim-lua/plenary.nvim" },
     config = function()
       require("crates").setup {
         null_ls = {


### PR DESCRIPTION
Fixes issue https://github.com/LunarVim/starter.lvim/issues/65.