### PR TITLE
fix:dap-python entries duplication

### DIFF
--- a/config.lua
+++ b/config.lua
@@ -26,7 +26,11 @@ linters.setup { { command = "flake8", filetypes = { "python" } } }
 lvim.builtin.dap.active = true
 local mason_path = vim.fn.glob(vim.fn.stdpath "data" .. "/mason/")
 pcall(function()
-  require("dap-python").setup(mason_path .. "packages/debugpy/venv/bin/python")
+  -- Without this check each time neovim loads this file the configurations for dap-python will
+  -- be inserted again which will start duplicating entries.
+  if not package.loaded['dap-python'] then
+    require("dap-python").setup(mason_path .. "packages/debugpy/venv/bin/python")
+  end
 end)
 
 -- setup testing


### PR DESCRIPTION
Each time dap-python is setup it [re-inserts](https://github.com/mfussenegger/nvim-dap-python/blob/master/lua/dap-python.lua#L175) the configurations for debugpy again.

This leads to duplicated entries for available options to run each time a new Python file is opened on nvim/lvim.

This PR proposes only setting up dap-python again if it hasn't been loaded yet (it fixed the issue for me but I'll send as a draft so others can confirm this behavior).