### PR TITLE
fix lsp server names

### DIFF
--- a/config.lua
+++ b/config.lua
@@ -12,11 +12,11 @@ lvim.builtin.treesitter.ensure_installed = {
 }
 
 lvim.lsp.installer.setup.ensure_installed = {
-  "sumeko_lua",
-  "css-lsp",
-  "typescript-language-server",
-  "tailwindcss-language-server",
-  "elixir-ls"
+  "lua_ls",
+  "cssls",
+  "tsserver",
+  "tailwindcss",
+  "elixirls"
 }
 
 -- Additional Plugins


### PR DESCRIPTION
sumeko_lua -> lua_ls
css-lsp -> cssls
tailwindcss-language-server -> tsserver
elixir-ls -> elixirls

Otherwise, warnings like the following are reported:

[mason-lspconfig.nvim] Server "elixir-ls" is not a valid entry in ensure_installed. Make sure to only provide lspconfig server names.