### PR TITLE
Rust ide

### DIFF
--- a/config.lua
+++ b/config.lua
@@ -13,16 +13,19 @@ formatters.setup {
 }
 
 local mason_path = vim.fn.glob(vim.fn.stdpath "data" .. "/mason/")
-local codelldb_adapter = {
-  type = "server",
-  port = "${port}",
-  executable = {
-    command = mason_path .. "bin/codelldb",
-    args = { "--port", "${port}" },
-    -- On windows you may have to uncomment this:
-    -- detached = false,
-  },
-}
+
+local codelldb_path = mason_path .. "bin/codelldb"
+local liblldb_path = mason_path .. "packages/codelldb/extension/lldb/lib/liblldb"
+local this_os = vim.loop.os_uname().sysname
+
+-- The path in windows is different
+if this_os:find "Windows" then
+  codelldb_path = mason_path .. "packages\\codelldb\\extension\\adapter\\codelldb.exe"
+  liblldb_path = mason_path .. "packages\\codelldb\\extension\\lldb\\bin\\liblldb.dll"
+else
+  -- The liblldb extension is .so for linux and .dylib for macOS
+  liblldb_path = liblldb_path .. (this_os == "Linux" and ".so" or ".dylib")
+end
 
 pcall(function()
   require("rust-tools").setup {
@@ -57,7 +60,8 @@ pcall(function()
       end,
     },
     dap = {
-      adapter = codelldb_adapter,
+      -- adapter= codelldb_adapter,
+      adapter = require("rust-tools.dap").get_codelldb_adapter(codelldb_path, liblldb_path),
     },
     server = {
       on_attach = function(client, bufnr)
@@ -83,7 +87,7 @@ pcall(function()
 end)
 
 lvim.builtin.dap.on_config_done = function(dap)
-  dap.adapters.codelldb = codelldb_adapter
+  dap.adapters.codelldb = require("rust-tools.dap").get_codelldb_adapter(codelldb_path, liblldb_path)
   dap.configurations.rust = {
     {
       name = "Launch file",

--- a/config.lua
+++ b/config.lua
@@ -7,11 +7,6 @@ lvim.builtin.treesitter.ensure_installed = {
 
 vim.list_extend(lvim.lsp.automatic_configuration.skipped_servers, { "rust_analyzer" })
 
-local formatters = require "lvim.lsp.null-ls.formatters"
-formatters.setup {
-  { command = "stylua", filetypes = { "lua" } },
-}
-
 local mason_path = vim.fn.glob(vim.fn.stdpath "data" .. "/mason/")
 
 local codelldb_path = mason_path .. "bin/codelldb"


### PR DESCRIPTION
The lua related formatting setup using astylua is unneccessary as lua_ls can provide  formatting.
Deleted the lua formatting part as discussed. 
deleted code is 
```lua
local formatters = require "lvim.lsp.null-ls.formatters"
formatters.setup {
  { command = "stylua", filetypes = { "lua" } },
}
```