### PR TITLE
Fix deprecated lvim.lsp.diagnostics.virtual_text

### DIFF
--- a/config.lua
+++ b/config.lua
@@ -1,5 +1,5 @@
 lvim.format_on_save = false
-lvim.lsp.diagnostics.virtual_text = true
+vim.diagnostic.config = true
 
 lvim.builtin.treesitter.highlight.enable = true
 


### PR DESCRIPTION
`lvim.lsp.diagnostics.virtual_text` is deprecated.
 Use `vim.diagnostic.config({ virtual_text = true })` instead.